### PR TITLE
In scripts/run_evaluation.sh there is a typo that leads to an error a…

### DIFF
--- a/scripts/run_evaluation.sh
+++ b/scripts/run_evaluation.sh
@@ -198,7 +198,7 @@ echo "  verbosity:           $VERBOSITY"
 echo "  include_path:        $INCLUDE_PATH"
 echo "  output_path:         $OUTPUT_PATH"
 echo "  trust_remote_code:   $TRUST_REMOTE_CODE"
-echo "  chat_template:       $CHAT_TEMPLATE
+echo "  chat_template:       $CHAT_TEMPLATE"
 [[ -n "$USE_CACHE_PATH" ]] && echo "  use_cache:           $USE_CACHE_PATH"
 echo
 


### PR DESCRIPTION
Сейчас при попытке запустить оценку модели по инструкции получаю ошибку:

> bash ./scripts/run_evaluation.sh \                     
>  --model local-completions \
>  --model_args "model=Qwen/Qwen3-4B-Instruct-2507,base_url=http://localhost:8000/v1/completions,tokenizer_backend=huggingface,tokenizer=Qwen/Qwen3-4B-Instruct-2507,tensor_parallel_size=1" \
>  --output_path "./results/Qwen3-4B-Instruct-2507"
> → Evaluating 11 task(s): rucodeeval
> codelintereval
> rucodereviewer
> ruhumaneval
> strucom
> unittests
> codecorrectness
> realcode
> realcodejava
> javatestgen
> yabloco
>   engine:              local-completions
>   model_args:          model=Qwen/Qwen3-4B-Instruct-2507,base_url=http://localhost:8000/v1/completions,tokenizer_backend=huggingface,tokenizer=Qwen/Qwen3-4B-Instruct-2507,tensor_parallel_size=1
>   gen_kwargs:          
>   device:              cuda
>   batch_size:          1
>   predict_only:        true
>   log_samples:         true
>   verbosity:           ERROR
>   include_path:        ./code_tasks
>   output_path:         ./results/Qwen3-4B-Instruct-2507
>   trust_remote_code:   false
> ./scripts/run_evaluation.sh: строка 213: синтаксическая ошибка рядом с неожиданным маркером «(»

проблема в пропущенной закрывающей кавычке, которую я добавил

в исправленной версии эта команда запустилась без ошибок