### PR TITLE
Unit_tests: Fix the dimensions of lists with generations in the calculation of CodeBLEU metric

### DIFF
--- a/code_tasks/unit_tests/utils.py
+++ b/code_tasks/unit_tests/utils.py
@@ -102,7 +102,6 @@ def get_code_from_markdown(text: str, language: str = "python") -> list[str]:
 
 def process_results(doc: dict, results: list[str]) -> dict[str, float]:
 
-    # results - двумерный список, распаковываем его
     gen_test = results[0]
     processed_gen_test = get_code_from_markdown(gen_test, doc["inputs"]["language"])
 


### PR DESCRIPTION
Изменена обработка списка с генерацией при подсчете метрики в функции process_results: results распаковывается один раз, так как это одномерный список.